### PR TITLE
Update Info class based on the Nats source

### DIFF
--- a/src/Message/Info.php
+++ b/src/Message/Info.php
@@ -10,19 +10,29 @@ class Info extends Prototype
     public string $server_name;
     public string $version;
     public int $proto;
-    public string $git_commit;
+    public ?string $git_commit;
     public string $go;
     public string $host;
     public int $port;
     public bool $headers;
+    public ?bool $auth_required;
+    public ?bool $tls_required;
+    public ?bool $tls_verify;
+    public ?bool $tls_available;
     public int $max_payload;
-    public bool $jetstream;
-    public int $client_id;
-    public string $client_ip;
-    public bool $auth_required;
-
-    public ?string $cluster = null;
-    public ?array $connect_urls = null;
+    public ?bool $jetstream;
+    public ?string $ip;
+    public ?int $client_id;
+    public ?string $client_ip;
+    public ?string $nonce;
+    public ?string $cluster;
+    public ?bool $cluster_dynamic;
+    public ?string $domain;
+    /** @var string[]|null  */
+    public ?array $connect_urls;
+    /** @var string[]|null  */
+    public ?array $ws_connect_urls;
+    public ?bool $ldm;
 
     public function render(): string
     {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Basis\Nats\Tests;
+
+use Basis\Nats\Message\Factory;
+use Basis\Nats\Message\Info;
+
+class FactoryTest extends Test
+{
+    public function testInfo()
+    {
+        $infoData = [
+            "server_id" => "ID",
+            "server_name" => "NAME",
+            "version" => "1.0",
+            "proto" => 1,
+            "go" => "1",
+            "host" => "host",
+            "port" => 1234,
+            "headers" => false,
+            "domain" => "domain"
+        ];
+        $infoString = "INFO " . json_encode($infoData);
+        
+        $message = Factory::create($infoString);
+        
+        $this->assertEquals(Info::class, get_class($message));
+    }
+}


### PR DESCRIPTION
In our setup, Invalid property domain for message Basis\Nats\Message\Info error is thrown when this library connects to a leaf node.

Domain is not a valid option for INFO, but the go source code includes it with some additional attributes:
https://github.com/nats-io/nats-server/blob/95caa6ba363c204f2d33189a85fa119b0f2c5190/server/server.go#L61

In my understanding only the first block of attributes are required, because those are send to the client.

A future proof solution could be to remove the `InvalidArgumentException` from `Prototype`, and allow for unknown attributes as well.