### PR TITLE
Added support for TLS 1.2 including client cert verification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,48 @@ $client = new Client($configuration);
 $client->ping(); // true
 
 ```
+
+### Connecting to a cluster with TLS enabled
+Typically, when connecting to a cluster with TLS enabled the connection settings do not change. The client lib will automatically switch over to TLS 1.2. However, if you're using a self-signed certificate you may have to point to your local CA file using the tlsCaFile setting. 
+
+When connecting to a nats cluster that requires the client to provide TLS certificates use the tlsCertFile and tlsKeyFile to point at your local TLS certificate and private key file. 
+
+Nats Server documentation for:
+- [Enabling TLS](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls)
+- [Enabling TLS Authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tls_mutual_auth)
+- [Creating self-signed TLS certs for Testing](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls#self-signed-certificates-for-testing)
+
+Connection settings when connecting to a nats server that has TLS and TLS Client verify enabled.
+```php
+use Basis\Nats\Client;
+use Basis\Nats\Configuration;
+
+// this is default options, you can override anyone
+$configuration = new Configuration([
+    'host' => 'localhost',
+    'jwt' => null,
+    'lang' => 'php',
+    'pass' => null,
+    'pedantic' => false,
+    'port' => 4222,
+    'reconnect' => true,
+    'timeout' => 1,
+    'token' => null,
+    'user' => null,
+    'nkey' => null,
+    'verbose' => false,
+    'version' => 'dev',
+    'tlsCertFile' => "./certs/client-cert.pem",
+    'tlsKeyFile'  => "./certs/client-key.pem",
+    'tlsCaFile'  => "./certs/client-key.pem",
+]);
+
+$configuration->setDelay(0.001);
+
+$client = new Client($configuration);
+$client->ping(); // true
+```
+
 ## Publish Subscribe
 
 ```php

--- a/docker/certs/.gitignore
+++ b/docker/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "4220:4222"
       - "8220:8222"
-    command: -js -m 8222 --tls --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem --tlscacert=/certs/rootCA.pem
+    command: -js -m 8222 --tls --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem --tlscacert=/certs/rootCA.pem --tlsverify
     volumes:
       - ./certs:/certs:ro
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "4220:4222"
       - "8220:8222"
-    command: -js -m 8222 --tls --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem --tlscacert=/certs/rootCA.pem --tlsverify
+    command: -js -m 8222 --tls --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem --tlscacert=/certs/rootCA.pem
     volumes:
       - ./certs:/certs:ro
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,18 @@ services:
     depends_on:
       credentials-generator:
         condition: service_completed_successfully
+  nats-with-certs:
+    image: nats:alpine
+    restart: unless-stopped
+    ports:
+      - "4220:4222"
+      - "8220:8222"
+    command: -js -m 8222 --tls --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem --tlscacert=/certs/rootCA.pem --tlsverify
+    volumes:
+      - ./certs:/certs:ro
+    depends_on:
+      certs-generator:
+        condition: service_completed_successfully
   credentials-generator:
     image: natsio/nats-box:latest
     volumes:
@@ -26,3 +38,11 @@ services:
       - ./credentials:/credentials
     working_dir: /app
     command: generate-credentials.sh
+  certs-generator:
+    image: goodeggs/mkcert
+    entrypoint: /bin/bash
+    volumes:
+      - ./scripts:/app:ro
+      - ./certs:/certs
+    working_dir: /app
+    command: generate-certs.sh

--- a/docker/scripts/generate-certs.sh
+++ b/docker/scripts/generate-certs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+cd /certs
+
+echo "Delete files from previous run"
+rm -f ./rootCA.pem
+rm -f ./server-cert.pem
+rm -f ./server-key.pem
+rm -f ./client-cert.pem
+rm -f ./client-key.pem
+
+
+echo "Setup CA cert";
+/usr/local/bin/mkcert -install
+
+echo "Generate server certs";
+/usr/local/bin/mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1
+
+echo "Generate client certs";
+/usr/local/bin/mkcert -client -cert-file client-cert.pem -key-file client-key.pem localhost ::1 email@localhost
+
+echo "Copy CA file to certs directory";
+cp "$(mkcert -CAROOT)/rootCA.pem" /certs

--- a/docker/scripts/generate-certs.sh
+++ b/docker/scripts/generate-certs.sh
@@ -20,3 +20,5 @@ echo "Generate client certs";
 
 echo "Copy CA file to certs directory";
 cp "$(mkcert -CAROOT)/rootCA.pem" /certs
+
+chmod 644 /certs/client-key.pem

--- a/docker/scripts/generate-certs.sh
+++ b/docker/scripts/generate-certs.sh
@@ -16,7 +16,7 @@ echo "Generate server certs";
 /usr/local/bin/mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1
 
 echo "Generate client certs";
-/usr/local/bin/mkcert -client -cert-file client-cert.pem -key-file client-key.pem localhost ::1 email@localhost
+/usr/local/bin/mkcert -client -cert-file client-cert.pem -key-file client-key.pem email@localhost
 
 echo "Copy CA file to certs directory";
 cp "$(mkcert -CAROOT)/rootCA.pem" /certs

--- a/src/Client.php
+++ b/src/Client.php
@@ -349,18 +349,28 @@ class Client
      *
      * @throws Exception
      */
-    public function enableTls(bool $requireClientCert): void
+    private function enableTls(bool $requireClientCert): void
     {
         if ($requireClientCert) {
             if (!empty($this->configuration->tlsKeyFile)) {
+                if (!file_exists($this->configuration->tlsKeyFile)) {
+                    throw new Exception("tlsKeyFile file does not exist: " . $this->configuration->tlsKeyFile);
+                }
                 stream_context_set_option($this->context, 'ssl', 'local_pk', $this->configuration->tlsKeyFile);
             }
             if (!empty($this->configuration->tlsCertFile)) {
+                if (!file_exists($this->configuration->tlsCertFile)) {
+                    throw new Exception("tlsCertFile file does not exist: " . $this->configuration->tlsCertFile);
+                }
                 stream_context_set_option($this->context, 'ssl', 'local_cert', $this->configuration->tlsCertFile);
             }
-            if (!empty($this->configuration->tlsCaFile)) {
-                stream_context_set_option($this->context, 'ssl', 'cafile', $this->configuration->tlsCaFile);
+        }
+
+        if (!empty($this->configuration->tlsCaFile)) {
+            if (!file_exists($this->configuration->tlsCaFile)) {
+                throw new Exception("tlsCaFile file does not exist: " . $this->configuration->tlsCaFile);
             }
+            stream_context_set_option($this->context, 'ssl', 'cafile', $this->configuration->tlsCaFile);
         }
 
         if (!stream_socket_enable_crypto(

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -24,6 +24,10 @@ class Configuration
     public readonly ?string $user;
     public readonly ?string $nkey;
 
+    public readonly ?string $tlsKeyFile;
+    public readonly ?string $tlsCertFile;
+    public readonly ?string $tlsCaFile;
+
     public const DELAY_CONSTANT = 'constant';
     public const DELAY_LINEAR = 'linear';
     public const DELAY_EXPONENTIAL = 'exponential';
@@ -46,6 +50,9 @@ class Configuration
         'verbose' => false,
         'version' => 'dev',
         'pingInterval' => 2,
+        'tlsKeyFile' => null,
+        'tlsCertFile' => null,
+        'tlsCaFile' => null,
     ];
 
     /**

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -73,6 +73,7 @@ class ClientTest extends FunctionalTestCase
             'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
         ]);
+        
         $client->ping();
     }
 

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -47,4 +47,56 @@ class ClientTest extends FunctionalTestCase
         $this->expectExceptionMessageMatches('/^Connection refused$|^A connection attempt failed/');
         $this->createClient(['port' => -1])->ping();
     }
+
+    public function testTLSConnection()
+    {
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
+        ]);
+
+        $this->assertTrue($client->ping());
+
+        $this->assertTrue($client->info->tls_required);
+        $this->assertTrue($client->info->tls_verify);
+    }
+
+
+    public function testInvalidTlsRootCa()
+    {
+        $this->expectExceptionMessageMatches("/tlsCaFile file does not exist*/");
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
+        ]);
+        $client->ping();
+    }
+
+    public function testInvalidTlsCert()
+    {
+        $this->expectExceptionMessageMatches("/tlsCertFile file does not exist*/");
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert-wrong.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
+        ]);
+        $client->ping();
+    }
+
+    public function testInvalidTlsKey()
+    {
+        $this->expectExceptionMessageMatches("/tlsKeyFile file does not exist*/");
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key-wrong.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
+        ]);
+        $client->ping();
+    }
 }

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -52,12 +52,15 @@ class ClientTest extends FunctionalTestCase
     {
         $client = $this->createClient([
             'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
         ]);
 
         $this->assertTrue($client->ping());
 
         $this->assertTrue($client->info->tls_required);
+        $this->assertTrue($client->info->tls_verify);
     }
 
 
@@ -71,4 +74,27 @@ class ClientTest extends FunctionalTestCase
         $client->ping();
     }
 
+    public function testInvalidTlsCert()
+    {
+        $this->expectExceptionMessageMatches("/tlsCertFile file does not exist*/");
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert-wrong.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
+        ]);
+        $client->ping();
+    }
+
+    public function testInvalidTlsKey()
+    {
+        $this->expectExceptionMessageMatches("/tlsKeyFile file does not exist*/");
+        $client = $this->createClient([
+            'port' => 4220,
+            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key-wrong.pem",
+            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
+        ]);
+        $client->ping();
+    }
 }

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -52,8 +52,8 @@ class ClientTest extends FunctionalTestCase
     {
         $client = $this->createClient([
             'port' => 4220,
-            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
-            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
+//            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
+//            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
         ]);
 
@@ -73,7 +73,6 @@ class ClientTest extends FunctionalTestCase
             'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
         ]);
-        
         $client->ping();
     }
 

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -52,15 +52,12 @@ class ClientTest extends FunctionalTestCase
     {
         $client = $this->createClient([
             'port' => 4220,
-//            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
-//            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
         ]);
 
         $this->assertTrue($client->ping());
 
         $this->assertTrue($client->info->tls_required);
-        $this->assertTrue($client->info->tls_verify);
     }
 
 
@@ -69,34 +66,9 @@ class ClientTest extends FunctionalTestCase
         $this->expectExceptionMessageMatches("/tlsCaFile file does not exist*/");
         $client = $this->createClient([
             'port' => 4220,
-            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
-            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
             'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
         ]);
         $client->ping();
     }
 
-    public function testInvalidTlsCert()
-    {
-        $this->expectExceptionMessageMatches("/tlsCertFile file does not exist*/");
-        $client = $this->createClient([
-            'port' => 4220,
-            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert-wrong.pem",
-            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key.pem",
-            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCAWrong.pem",
-        ]);
-        $client->ping();
-    }
-
-    public function testInvalidTlsKey()
-    {
-        $this->expectExceptionMessageMatches("/tlsKeyFile file does not exist*/");
-        $client = $this->createClient([
-            'port' => 4220,
-            'tlsCertFile' => $this->getProjectRoot() . "/docker/certs/client-cert.pem",
-            'tlsKeyFile'  => $this->getProjectRoot() . "/docker/certs/client-key-wrong.pem",
-            'tlsCaFile'   => $this->getProjectRoot() . "/docker/certs/rootCA.pem",
-        ]);
-        $client->ping();
-    }
 }


### PR DESCRIPTION
Updated the connection logic to convert the socket to TLS 1.2 when the server INFO message has the tls_required property set to true. If the INFO message has the tls_verify property set to true the code sets the client side TLS certificates for client authentication based on tls connection settings. 

The new connection settings options are: 
- tlsKeyFile
- tlsCertFile
- tlsCaFile 

Nats instructions for configuring a cluster with TLS: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tls_mutual_auth

```
use Basis\Nats\Client;
use Basis\Nats\Configuration;

// this is default options, you can override anyone
$configuration = new Configuration([
    'host' => 'localhost',
    'jwt' => null,
    'lang' => 'php',
    'pass' => null,
    'pedantic' => false,
    'port' => 4222,
    'reconnect' => true,
    'timeout' => 1,
    'token' => null,
    'user' => null,
    'nkey' => null,
    'verbose' => false,
    'version' => 'dev',
    'tlsCertFile' => "./certs/client-cert.pem",
    'tlsKeyFile'  => "./certs/client-key.pem",
]);

$configuration->setDelay(0.001);

$client = new Client($configuration);
$client->ping(); // true
```