### PR TITLE
Servers connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ $client = new Client($configuration);
 $client->ping(); // true
 ```
 
+As an alternative to the `host` and `port` configuration options you can specify an array of host/port values in the `server` option. When the array contains more than one entry the client will attempt to connect to each entry in turn. If it fails to connect it will go to the next entry in the array. 
+
+By default, the order of the host:port entries is randomly shuffled on startup. In situations where multiple clients have the same connection configuration this shuffle will balance the clients across multiple servers. If you want to manage client connections directly while also availing of the redundancy of multiple host:port configurations you can disable the shuffle by setting the `serversRandomize` option to false.
+
+```php
+use Basis\Nats\Client;
+use Basis\Nats\Configuration;
+
+
+$configuration = new Configuration([
+    'servers' => ['localhost:4222', 'localhost:4221', 'localhost:4220'],
+    'serversRandomize' => false
+]);
+
+// default delay mode is constant - first retry be in 1ms, second in 1ms, third in 1ms
+$configuration->setDelay(0.001);
+
+
+$client = new Client($configuration);
+$client->ping(); // true
+
+```
+
 ## Publish Subscribe
 
 ```php
@@ -296,19 +319,24 @@ model name  : Intel(R) Core(TM) i5-4670K CPU @ 3.40GHz
 
 The following is the list of configuration options and default values.
 
-| Option         | Default    | Description                                                                                                                                                                                                                   |
-|----------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `inboxPrefix`  | `"_INBOX"` | Sets de prefix for automatically created inboxes                                                                                                                                                                              |
-| `jwt`          |            | Token for [JWT Authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt). Alternatively you can use [CredentialsParser](#using-nkeys-with-jwt)                                  |
-| `nkey`         |            | Ed25519 based public key signature used for [NKEY Authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).                                                              |
-| `pass`         |            | Sets the password for a connection.                                                                                                                                                                                           |
-| `pedantic`     | `false`    | Turns on strict subject format checks.                                                                                                                                                                                        |
-| `pingInterval` | `2`        | Number of seconds between client-sent pings.                                                                                                                                                                                  |
-| `port`         | `4222`     | Port to connect to (only used if `servers` is not specified).                                                                                                                                                                 |
-| `timeout`      | 1          | Number of seconds the client will wait for a connection to be established. |
-| `token`        |            | Sets a authorization token for a connection.                                                                                                                                                                                  |
-| `tlsKeyFile`   |            | TLS 1.2 Client key file path.                                                                                                                                                                                                 |
-| `tlsCertFile`  |            | TLS 1.2 Client certificate file path.                                                                                                                                                                                         |
-| `tlsCaFile`    |            | TLS 1.2 CA certificate filepath.                                                                                                                                                                                              |
-| `user`         |            | Sets the username for a connection.                                                                                                                                                                                           |
-| `verbose`      | `false`    | Turns on `+OK` protocol acknowledgements.                                                                                                                                                                                     |
+| Option                 | Default    | Description                                                                                                                                                                                  |
+|------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ignoreClusterUpdates` | `false`    | If true the client will ignore `connect_urls` and `ldm` in INFO messages.                                                                                                                    |
+| `inboxPrefix`          | `"_INBOX"` | Sets de prefix for automatically created inboxes                                                                                                                                             |
+| `jwt`                  |            | Token for [JWT Authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt). Alternatively you can use [CredentialsParser](#using-nkeys-with-jwt) |
+| `maxReconnectAttempts` | 10         | Sets the maximum number of reconnect attempts per server. The value of -1 specifies no limit.                                                                                                |
+| `nkey`                 |            | Ed25519 based public key signature used for [NKEY Authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).                             |
+| `pass`                 |            | Sets the password for a connection.                                                                                                                                                          |
+| `pedantic`             | `false`    | Turns on strict subject format checks.                                                                                                                                                       |
+| `pingInterval`         | `2`        | Number of seconds between client-sent pings.                                                                                                                                                 |
+| `port`                 | `4222`     | Port to connect to (only used if `servers` is not specified).                                                                                                                                |
+| `reconnectTimeWait`    | `2000`     | If disconnected, the client will wait the specified number of miliseconds between reconnect attempts on a per server basis.                                                           |
+| `servers`              |            | Array of host:port values for servers                                                                                                                                                        |
+| `serversRandomize`     | `true`     | Toggle on/off the server array shuffle.                                                                                                                                                      |
+| `timeout`              | 1          | Number of seconds the client will wait for a connection to be established.                                                                                                                   |
+| `token`                |            | Sets a authorization token for a connection.                                                                                                                                                 |
+| `tlsKeyFile`           |            | TLS 1.2 Client key file path.                                                                                                                                                                |
+| `tlsCertFile`          |            | TLS 1.2 Client certificate file path.                                                                                                                                                        |
+| `tlsCaFile`            |            | TLS 1.2 CA certificate filepath.                                                                                                                                                             |
+| `user`                 |            | Sets the username for a connection.                                                                                                                                                          |
+| `verbose`              | `false`    | Turns on `+OK` protocol acknowledgements.                                                                                                                                                    |

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Basis\Nats;
 
+use Basis\Nats\Connection\ServersManager;
 use Basis\Nats\Message\Connect;
 use Basis\Nats\Message\Factory;
 use Basis\Nats\Message\Info;
@@ -28,6 +29,7 @@ class Client
     public readonly Api $api;
 
     private readonly ?Authenticator $authenticator;
+    private readonly ServersManager $serversManager;
 
     private $socket;
     private $context;
@@ -38,7 +40,11 @@ class Client
     private array $subscriptions = [];
 
     private bool $skipInvalidMessages = false;
+    private bool $tlsEnabled = false;
 
+    /**
+     * @throws Exception
+     */
     public function __construct(
         public readonly Configuration $configuration = new Configuration(),
         public ?LoggerInterface $logger = null,
@@ -46,6 +52,7 @@ class Client
         $this->api = new Api($this);
 
         $this->authenticator = Authenticator::create($this->configuration);
+        $this->serversManager = new ServersManager($this->configuration);
     }
 
     public function api($command, array $args = [], ?Closure $callback = null): ?object
@@ -82,12 +89,25 @@ class Client
 
         $config = $this->configuration;
 
-        $dsn = "$config->host:$config->port";
+        if ($this->serversManager->hasServers()) {
+            if ($this->serversManager->allExceededReconnectionAttempts()) {
+                throw new Exception("Connection error: maximum reconnect attempts exceeded for all servers.");
+            }
+            $dsn = $this->serversManager->nextServer()->getConnectionString();
+        } else {
+            $dsn = "$config->host:$config->port";
+        }
+
         $flags = STREAM_CLIENT_CONNECT;
         $this->context = stream_context_create();
         $this->socket = @stream_socket_client($dsn, $errorCode, $errorMessage, $config->timeout, $flags, $this->context);
 
         if ($errorCode || !$this->socket) {
+            if ($config->reconnect && $this->serversManager->hasServers()) {
+                $this->logger?->error("Error connecting to: (" . $dsn . ")");
+                $this->socket = null;
+                return $this->connect(); /** @phan-suppress-current-line PhanPossiblyInfiniteRecursionSameParams */
+            }
             throw new Exception($errorMessage ?: "Connection error", $errorCode);
         }
 
@@ -336,11 +356,15 @@ class Client
      */
     private function handleInfoMessage(Info $info): void
     {
-        if (isset($info->tls_verify) && $info->tls_verify) {
-            $this->enableTls(true);
-        } elseif (isset($info->tls_required) && $info->tls_required) {
-            $this->enableTls(false);
+        if (!$this->tlsEnabled) {
+            if (isset($info->tls_verify) && $info->tls_verify) {
+                $this->enableTls(true);
+            } elseif (isset($info->tls_required) && $info->tls_required) {
+                $this->enableTls(false);
+            }
         }
+
+        $this->serversManager->processInfoMessage($info);
     }
 
 
@@ -380,6 +404,7 @@ class Client
         )) {
             throw new Exception('Failed to connect: Error enabling TLS');
         }
+        $this->tlsEnabled = true;
     }
 
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -30,6 +30,12 @@ class Configuration
     public readonly ?string $tlsCertFile;
     public readonly ?string $tlsCaFile;
 
+    public readonly array $servers;
+    public readonly bool  $serversRandomize;
+    public readonly bool  $ignoreClusterUpdates;
+    public readonly int   $maxReconnectAttempts;
+    public readonly int   $reconnectTimeWait;
+
     public const DELAY_CONSTANT = 'constant';
     public const DELAY_LINEAR = 'linear';
     public const DELAY_EXPONENTIAL = 'exponential';
@@ -56,6 +62,11 @@ class Configuration
         'tlsKeyFile' => null,
         'tlsCertFile' => null,
         'tlsCaFile' => null,
+        'servers' => [],
+        'serversRandomize' => true,
+        'ignoreClusterUpdates' => false,
+        'maxReconnectAttempts' => 10,
+        'reconnectTimeWait' => 2000
     ];
 
     /**
@@ -80,6 +91,7 @@ class Configuration
             'verbose' => $this->verbose,
             'version' => $this->version,
             'headers' => true,
+            'protocol' => 1,
         ];
 
         if ($this->user !== null) {

--- a/src/Connection/Server.php
+++ b/src/Connection/Server.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Basis\Nats\Connection;
+
+use Exception;
+
+class Server
+{
+    private readonly string $host;
+    public readonly int $port;
+    public int $reconnectAttempts;
+    public bool $lameDuck;
+    public bool $gossiped;
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(string $hostport, bool $gossiped = false)
+    {
+        if (empty($hostport) || !str_contains($hostport, ':') || 2 !== sizeof(explode(":", $hostport))) {
+            throw new Exception("Invalid server configuration: " .$hostport);
+        }
+
+        $parts = explode(":", $hostport);
+
+        if (empty($parts[0]) || !is_numeric($parts[1])) {
+            throw new Exception("Invalid server configuration: " .$hostport);
+        }
+
+        $this->host = $parts[0];
+        $this->port = intval($parts[1]);
+        $this->gossiped = $gossiped;
+        $this->lameDuck = false;
+        $this->reconnectAttempts = -1;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConnectionString(): string
+    {
+        return $this->host . ":" . $this->port;
+    }
+
+    /**
+     */
+    public function incrementReconnectAttempts(): void
+    {
+        $this->reconnectAttempts = $this->reconnectAttempts + 1;
+    }
+
+    /**
+     * @return int
+     */
+    public function getReconnectAttempts(): int
+    {
+        return $this->reconnectAttempts;
+    }
+
+    /**
+     * @return int
+     */
+    public function resetReconnectAttempts(): int
+    {
+        return $this->reconnectAttempts = 0;
+    }
+
+    /**
+     */
+    public function setLameDuck(bool $lameDuck): void
+    {
+        $this->lameDuck = $lameDuck;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLameDuck(): bool
+    {
+        return $this->lameDuck;
+    }
+}

--- a/src/Connection/ServersManager.php
+++ b/src/Connection/ServersManager.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Basis\Nats\Connection;
+
+use Basis\Nats\Configuration;
+use Basis\Nats\Message\Info;
+use Exception;
+use ArrayIterator;
+
+class ServersManager
+{
+    private ArrayIterator $serversIterator;
+    private readonly bool $ignoreClusterUpdates;
+    private readonly bool $serversRandomize;
+    private readonly int  $reconnectTimeWait;
+    private readonly int  $maxReconnectsAllowed;
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(Configuration $conf)
+    {
+        $this->serversRandomize = $conf->serversRandomize;
+        $this->ignoreClusterUpdates = $conf->ignoreClusterUpdates;
+        $this->maxReconnectsAllowed = $conf->maxReconnectAttempts;
+        $this->reconnectTimeWait = $conf->reconnectTimeWait;
+
+        $serverConfigs = $conf->servers;
+
+        if ($this->serversRandomize) {
+            shuffle($serverConfigs);
+        }
+
+        $this->serversIterator = new ArrayIterator(array_map(
+            function ($e) {
+                return new Server($e);
+            },
+            $serverConfigs
+        ));
+    }
+
+    public function allExceededReconnectionAttempts(): bool
+    {
+        if ($this->hasServers()) {
+            $arr = $this->serversIterator->getArrayCopy();
+            foreach ($arr as $e) {
+                if ($e->getReconnectAttempts() < $this->maxReconnectsAllowed && !$e->isLameDuck()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public function totalReconnectionAttempts(): int
+    {
+        if ($this->hasServers()) {
+            $arr = $this->serversIterator->getArrayCopy();
+            return array_reduce($arr, function ($carry, $e) {
+                return $carry + $e->getReconnectAttempts();
+            });
+        }
+        return 0;
+    }
+
+    public function hasServers(): bool
+    {
+        return $this->serversIterator->count() > 0;
+    }
+
+    /**
+     * @return Server
+     * @throws Exception
+     */
+    public function nextServer(): Server
+    {
+        $counter = 0;
+        $max = ($this->maxReconnectsAllowed +1) * $this->serversIterator->count();
+
+        while ($counter++ < $max) {
+            $current = $this->serversIterator->current();
+            $current->incrementReconnectAttempts();
+
+            $this->serversIterator->next();
+
+            if (!$this->serversIterator->valid()) {
+                $this->serversIterator->rewind();
+            }
+
+            if ($current->getReconnectAttempts() <= $this->maxReconnectsAllowed && !$current->isLameDuck()) {
+                if ($current->getReconnectAttempts() > 0 && $this->reconnectTimeWait > 0) {
+                    usleep((int) floor($this->reconnectTimeWait * 1_000));
+                }
+                return $current;
+            }
+        }
+
+        throw new Exception("Connection error: maximum reconnect attempts exceeded for all servers.");
+    }
+
+
+    /**
+     * @throws Exception
+     */
+    public function processInfoMessage(Info $message): void
+    {
+        if (!$this->ignoreClusterUpdates) {
+            if (isset($message->ldm) && $message->ldm) {
+                $server = $this->serversIterator->current();
+                $server->setLameDuck(true);
+            };
+
+            if (isset($message->connect_urls) && !empty($message->connect_urls)) {
+                $clusterUrls = $message->connect_urls;
+                $arrCopy = $this->serversIterator->getArrayCopy();
+
+                $arrConns = array_map(function ($e) {
+                    return $e->getConnectionString();
+                }, $arrCopy);
+
+                $toBeRemoved = array_diff($arrConns, $clusterUrls);
+                $toBeAdded   = array_diff($clusterUrls, $arrConns);
+
+                $newArr = array_filter($arrCopy, function ($e) use ($toBeRemoved) {
+                    return !in_array($e->getConnectionString(), $toBeRemoved);
+                });
+
+                foreach ($toBeAdded as $e) {
+                    $newArr[] = new Server($e, true);
+                }
+
+                if ($this->serversRandomize) {
+                    shuffle($newArr);
+                }
+
+                //reset lame duck mode when included on the server list
+                array_walk($newArr, function ($e) use ($clusterUrls) {
+                    $e->resetReconnectAttempts();
+                    $conn = $e->getConnectionString();
+                    if (in_array($conn, $clusterUrls)) {
+                        $e->setLameDuck(false);
+                    }
+                });
+
+                $this->serversIterator = new ArrayIterator($newArr);
+            }
+        }
+    }
+}

--- a/src/Message/Connect.php
+++ b/src/Message/Connect.php
@@ -15,7 +15,7 @@ class Connect extends Prototype
     public string $lang;
     public string $name;
     public string $pass;
-    public string $protocol;
+    public int $protocol;
     public string $sig;
     public string $tls_required;
     public string $user;

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Functional;
+
+use Basis\Nats\Client;
+use Basis\Nats\Configuration;
+use Basis\Nats\Connection\ServersManager;
+use Tests\TestCase;
+use ReflectionProperty;
+use Tests\Utils\Logger;
+
+class ConnectionTest extends TestCase
+{
+    use Logger;
+
+    public function testDefaultConfig()
+    {
+        $client = $this->createClient([]);
+
+        $this->assertTrue($client->ping());
+    }
+
+
+    public function testSingleServerEntry()
+    {
+        $client = $this->createClient([
+            'servers' => ["localhost:4222"],
+            'reconnect' => true,
+            'reconnectTimeWait' => 50,
+            'maxReconnectAttempts' => 10,
+            'serversRandomize' => false
+        ]);
+
+        $this->assertTrue($client->ping());
+    }
+
+    public function testOnlyOneServerUp()
+    {
+        $client = $this->createClient([
+            'servers' => ["localhost:3222", "localhost:3223", "localhost:3224", "localhost:4222" ],
+            'reconnect' => true,
+            'reconnectTimeWait' => 50,
+            'maxReconnectAttempts' => 0,
+            'serversRandomize' => false
+        ]);
+
+        $this->assertTrue($client->ping());
+    }
+
+    public function testReconnectsAttempts()
+    {
+        $property = new ReflectionProperty(Client::class, 'serversManager');
+        $property->setAccessible(true);
+
+        $manager = null;
+        try {
+            $client = $this->createClient([
+                'servers' => ["localhost:3222", "localhost:3223", "localhost:3224" ],
+                'reconnect' => true,
+                'reconnectTimeWait' => 10,
+                'maxReconnectAttempts' => 5,
+                'serversRandomize' => false
+            ]);
+
+            /**
+             * @var $manager ServersManager
+             */
+            $manager = $property->getValue($client);
+
+            $this->assertFalse($manager->allExceededReconnectionAttempts());
+            $this->assertEquals(-3, $manager->totalReconnectionAttempts());
+
+            $client->ping();
+        } catch (\Exception $e) {
+        }
+
+        $this->assertTrue($manager->allExceededReconnectionAttempts());
+        $this->assertEquals(15, $manager->totalReconnectionAttempts());
+    }
+
+
+    public function testMaximumReconnectsExceeded()
+    {
+        $this->expectExceptionMessage("Connection error: maximum reconnect attempts exceeded for all servers.");
+        $client = $this->createClient([
+            'servers' => ["localhost:3222", "localhost:3223", "localhost:3224" ],
+            'reconnect' => true,
+            'reconnectTimeWait' => 50,
+            'maxReconnectAttempts' => 10,
+            'serversRandomize' => false
+        ]);
+        $client->ping();
+    }
+
+
+    /**
+     * @throws \Exception
+     */
+    private function createClient(array $options): \Basis\Nats\Client
+    {
+        $logger = null;
+        if (getenv('NATS_CLIENT_LOG')) {
+            $logger = $this->getLogger();
+        }
+
+        return new Client(new Configuration($options), $logger);
+    }
+}

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -27,4 +27,21 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('user', $connection->getOptions());
         $this->assertArrayHasKey('pass', $connection->getOptions());
     }
+
+    public function testServersOption()
+    {
+        $config = new Configuration(
+            [
+            "servers" => ["localhost:4222", "localhost:4221"]]
+        );
+
+        $this->assertEquals(["localhost:4222", "localhost:4221"], $config->servers);
+    }
+
+    public function testEmptyServersOption()
+    {
+        $config = new Configuration([]);
+
+        $this->assertEquals([], $config->servers);
+    }
 }

--- a/tests/Unit/Connection/ServersManagerTest.php
+++ b/tests/Unit/Connection/ServersManagerTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Tests\Unit\Connection;
+
+use Basis\Nats\Client;
+use Basis\Nats\Configuration;
+use Basis\Nats\Connection\ServersManager;
+use Basis\Nats\Message\Info;
+use Tests\TestCase;
+use ReflectionProperty;
+
+class ServersManagerTest extends TestCase
+{
+    /**
+     * @throws \Exception
+     */
+    public function testBasicSetup()
+    {
+        $config = new Configuration(
+            [
+                "servers" => ["host1:4222", "host2:4222", "host3:4222", "host4:4222", "host5:4222"],
+                'reconnect' => true,
+                'reconnectTimeWait' => 10,
+                'maxReconnectAttempts' => 3,
+                'serversRandomize' => false
+            ]
+        );
+
+        $manager = new ServersManager($config);
+
+        //Initial Connections
+        $this->assertTrue($manager->hasServers());
+        $this->assertFalse($manager->allExceededReconnectionAttempts());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host3:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host4:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host5:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertTrue($manager->hasServers());
+        $this->assertFalse($manager->allExceededReconnectionAttempts());
+        $this->assertEquals(0, $manager->totalReconnectionAttempts());
+
+        //Reconnection Attempts
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host3:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host4:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host5:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertTrue($manager->hasServers());
+        $this->assertFalse($manager->allExceededReconnectionAttempts());
+        $this->assertEquals(5, $manager->totalReconnectionAttempts());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host3:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host4:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host5:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertTrue($manager->hasServers());
+        $this->assertFalse($manager->allExceededReconnectionAttempts());
+        $this->assertEquals(10, $manager->totalReconnectionAttempts());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host3:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host4:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host5:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertTrue($manager->hasServers());
+        $this->assertTrue($manager->allExceededReconnectionAttempts());
+        $this->assertEquals(15, $manager->totalReconnectionAttempts());
+    }
+
+
+    /**
+     * @throws \Exception
+     */
+    public function testRandomize()
+    {
+        $config = new Configuration(
+            [
+                "servers" => ["host1:4222", "host2:4222", "host3:4222", "host4:4222", "host5:4222"],
+                'serversRandomize' => false
+            ]
+        );
+
+        $manager = new ServersManager($config);
+
+        $this->assertTrue($manager->hasServers());
+
+        $arr = $this->getServersArr($manager);
+
+        $all = array_reduce($arr, function ($cur, $e) {
+            return $cur . '-->' . $e->getConnectionString();
+        });
+
+        $this->assertEquals('-->host1:4222-->host2:4222-->host3:4222-->host4:4222-->host5:4222', $all);
+
+        $config = new Configuration(
+            [
+                "servers" => ["host1:4222", "host2:4222", "host3:4222", "host4:4222", "host5:4222"],
+                'serversRandomize' => true
+            ]
+        );
+
+        $manager = new ServersManager($config);
+
+        $this->assertTrue($manager->hasServers());
+
+        $arr = $this->getServersArr($manager);
+
+        $all = array_reduce($arr, function ($cur, $e) {
+            return $cur . '-->' . $e->getConnectionString();
+        });
+
+        $this->assertNotEquals('-->host1:4222-->host2:4222-->host3:4222-->host4:4222-->host5:4222', $all);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testReconnectionAttemptsExceeded()
+    {
+        $this->expectExceptionMessage("Connection error: maximum reconnect attempts exceeded for all servers.");
+
+        $config = new Configuration(
+            [
+                "servers" => ["host1:4222", "host2:4222"],
+                'serversRandomize' => false,
+                'reconnect' => true,
+                'reconnectTimeWait' => 10,
+                'maxReconnectAttempts' => 2,
+            ]
+        );
+
+        $manager = new ServersManager($config);
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+
+        $this->assertEquals("host1:4222", $manager->nextServer()->getConnectionString());
+        $this->assertEquals("host2:4222", $manager->nextServer()->getConnectionString());
+    }
+
+
+    /**
+     * @throws \Exception
+     */
+    public function testHandleInfo()
+    {
+        $config = new Configuration(
+            [
+                "servers" => ["localhost:4222", "localhost:4221"]]
+        );
+
+        $manager = new ServersManager($config);
+
+        $this->assertTrue($manager->hasServers());
+
+        $info = new Info([
+            'ldm'  => true,
+            'connect_urls' => ["localhost:4222", "localhost:4220"]
+            ]);
+
+        $manager->processInfoMessage($info);
+
+        $this->assertTrue($manager->hasServers());
+    }
+
+
+    /**
+     * @throws \Exception
+     */
+    public function testEmptyServerArray()
+    {
+        $config = new Configuration([]);
+
+        $manager = new ServersManager($config);
+
+        $this->assertFalse($manager->hasServers());
+
+        $this->assertEquals(0, $manager->totalReconnectionAttempts());
+    }
+
+
+    public function testInvalidServerHostPort1()
+    {
+        $this->expectExceptionMessage("Invalid server configuration: localhost:4222:8080");
+
+        $config = new Configuration(
+            [
+                "servers" => ["localhost:4222:8080"]]
+        );
+
+        new ServersManager($config);
+    }
+
+
+    public function testInvalidServerHostPort2()
+    {
+        $this->expectExceptionMessage("Invalid server configuration: localhost");
+
+        $config = new Configuration(
+            [
+                "servers" => ["localhost"]]
+        );
+
+        new ServersManager($config);
+    }
+
+    public function testInvalidServerHostPort3()
+    {
+        $this->expectExceptionMessage("Invalid server configuration: :");
+
+        $config = new Configuration(
+            [
+                "servers" => [":"]]
+        );
+
+        new ServersManager($config);
+    }
+
+    public function testInvalidServerHostPort4()
+    {
+        $this->expectExceptionMessage("Invalid server configuration: localhost:port");
+
+        $config = new Configuration(
+            [
+                "servers" => ["localhost:port"]]
+        );
+
+        new ServersManager($config);
+    }
+
+    private function getServersArr(ServersManager $manager): array
+    {
+        $property = new ReflectionProperty(ServersManager::class, 'serversIterator');
+        $property->setAccessible(true);
+        $iterator = $property->getValue($manager);
+
+        return $iterator->getArrayCopy();
+    }
+}


### PR DESCRIPTION
Here's the first draft of my reworking the connection and reconnection logic. Open issue: https://github.com/basis-company/nats.php/issues/19

I've added four new connection config options that roughly match up with the options on the nodejs/deno client libs. I'm creating this as a draft pull request as there are a few items that I need feedback on. They are:  

1. I've added a recursive call to the connect function. Phan is complaining about it but I can't come up with an alternative that doesn't rely on the recursive call. 
2. For the `reconnectTimeWait` param I went with milliseconds whereas other time based params are in seconds. Should we consider switching to milliseconds for all time based params.  
3. I have unit tests for handling the server INFO message updates, but no functional tests as I can't figure out how to put the server into lame duck mode from php. 
4. I'm not happy with the name I came up with for the ServersManager class. Can you think of anything better?   

