### PR TITLE
fix: do not process partly sent messages

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -298,10 +298,12 @@ class Client
                     while (strlen($payload) < $message->length) {
                         $line = stream_get_line($this->socket, $message->length);
                         if (!$line) {
-                            if ($iteration > 16) {
+                            $isEof = stream_get_meta_data($this->socket)['eof'] ?? false;
+
+                            if ($isEof || $iteration > 16) {
                                 $exception = new LogicException("No payload for message $message->sid");
                                 $this->processSocketException($exception);
-                                break;
+                                break 2;
                             }
                             $this->configuration->delay($iteration++);
                             continue;


### PR DESCRIPTION
In case of slow consumers NATS stops to write data into socket. Moreover, NATS can stop writing in the middle of the message. In this case Client::process method is trying to read message 16 times and then throws exception or reconnects to NATS. When reconnect is performed Client::process method is trying to process partly read message. This behaviour leads to "No handler for message <some sid>" because of re-subscribe logic in Client::processSocketException method. Also this behaviour does not make any sense. Message payload is not full and can't be deserialized in most cases.