### PR TITLE
feat: parse jet stream message timestamp

### DIFF
--- a/src/Message/Payload.php
+++ b/src/Message/Payload.php
@@ -24,7 +24,8 @@ class Payload
     public function __construct(
         public string $body,
         public array $headers = [],
-        public ?string $subject = null
+        public ?string $subject = null,
+        public ?int $timestampNanos = null
     ) {
         $hdrs = $this->getValue('message.hdrs');
         if ($hdrs) {

--- a/tests/Functional/StreamTest.php
+++ b/tests/Functional/StreamTest.php
@@ -14,6 +14,8 @@ class StreamTest extends FunctionalTestCase
 {
     private mixed $called;
 
+    private bool $empty;
+
     public function testDeduplication()
     {
         $stream = $this->getClient()->getApi()->getStream('tester');
@@ -213,6 +215,7 @@ class StreamTest extends FunctionalTestCase
 
         $this->assertNotNull($this->called);
         $this->assertSame($this->called->name, 'nekufa');
+        $this->assertNotNull($this->called->timestampNanos);
 
         $this->called = null;
         $consumer = $stream->getConsumer('bye');


### PR DESCRIPTION
When JetStream message is pulled from the stream `replyTo` field contains some useful information.
This PR parse message timestamp in nanoseconds - the time when message was pushed to the stream.

Inspired by [js client for NATS](https://github.com/nats-io/nats.deno/blob/fd397655e390b36cd52119ec80ce3446f54cb614/nats-base-client/jsmsg.ts#L41)