### PR TITLE
feat: add methods to set delivery policy options

### DIFF
--- a/src/Consumer/Configuration.php
+++ b/src/Consumer/Configuration.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Basis\Nats\Consumer;
 
+use DateTimeInterface;
+
 class Configuration
 {
+    private const OPT_START_TIME_FORMAT = 'Y-m-d\TH:i:s.uP'; # ISO8601 with microseconds
+
     private bool $ephemeral = false;
     private ?bool $flowControl = null;
     private ?bool $headersOnly = null;
@@ -15,7 +19,7 @@ class Configuration
     private ?int $maxDeliver = null;
     private ?int $maxWaiting = null;
     private ?int $optStartSeq = null;
-    private ?int $optStartTime = null;
+    private ?DateTimeInterface $optStartTime = null;
     private ?string $deliverGroup = null;
     private ?string $deliverSubject = null;
     private ?string $description = null;
@@ -164,6 +168,18 @@ class Configuration
         return $this;
     }
 
+    public function setOptStartSeq(int $startSeq): self
+    {
+        $this->optStartSeq = $startSeq;
+        return $this;
+    }
+
+    public function setOptStartTime(DateTimeInterface $startTime): self
+    {
+        $this->optStartTime = $startTime;
+        return $this;
+    }
+
     public function setReplayPolicy(string $replayPolicy): self
     {
         $this->replayPolicy = ReplayPolicy::validate($replayPolicy);
@@ -201,7 +217,7 @@ class Configuration
                 break;
 
             case DeliverPolicy::BY_START_TIME:
-                $config['opt_start_time'] = $this->getOptStartTime();
+                $config['opt_start_time'] = $this->getOptStartTime()?->format(self::OPT_START_TIME_FORMAT);
                 break;
         }
 

--- a/src/Consumer/Configuration.php
+++ b/src/Consumer/Configuration.php
@@ -18,8 +18,8 @@ class Configuration
     private ?int $maxAckPending = null;
     private ?int $maxDeliver = null;
     private ?int $maxWaiting = null;
-    private ?int $optStartSeq = null;
-    private ?DateTimeInterface $optStartTime = null;
+    private ?int $startSequence = null;
+    private ?DateTimeInterface $startTime = null;
     private ?string $deliverGroup = null;
     private ?string $deliverSubject = null;
     private ?string $description = null;
@@ -109,14 +109,14 @@ class Configuration
         return $this->maxWaiting;
     }
 
-    public function getOptStartSeq()
+    public function getStartSequence()
     {
-        return $this->optStartSeq;
+        return $this->startSequence;
     }
 
-    public function getOptStartTime()
+    public function getStartTime()
     {
-        return $this->optStartTime;
+        return $this->startTime;
     }
 
     public function getReplayPolicy()
@@ -168,15 +168,15 @@ class Configuration
         return $this;
     }
 
-    public function setOptStartSeq(int $startSeq): self
+    public function setStartSequence(int $startSeq): self
     {
-        $this->optStartSeq = $startSeq;
+        $this->startSequence = $startSeq;
         return $this;
     }
 
-    public function setOptStartTime(DateTimeInterface $startTime): self
+    public function setStartTime(DateTimeInterface $startTime): self
     {
-        $this->optStartTime = $startTime;
+        $this->startTime = $startTime;
         return $this;
     }
 
@@ -213,11 +213,11 @@ class Configuration
 
         switch ($this->getDeliverPolicy()) {
             case DeliverPolicy::BY_START_SEQUENCE:
-                $config['opt_start_seq'] = $this->getOptStartSeq();
+                $config['opt_start_seq'] = $this->getStartSequence();
                 break;
 
             case DeliverPolicy::BY_START_TIME:
-                $config['opt_start_time'] = $this->getOptStartTime()?->format(self::OPT_START_TIME_FORMAT);
+                $config['opt_start_time'] = $this->getStartTime()?->format(self::OPT_START_TIME_FORMAT);
                 break;
         }
 

--- a/tests/Functional/DeliveryPolicyTest.php
+++ b/tests/Functional/DeliveryPolicyTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Functional;
+
+use Basis\Nats\Consumer\DeliverPolicy;
+use Basis\Nats\Message\Payload;
+use Basis\Nats\Stream\RetentionPolicy;
+use Basis\Nats\Stream\StorageBackend;
+use DateTime;
+use Tests\FunctionalTestCase;
+
+class DeliveryPolicyTest extends FunctionalTestCase
+{
+    public function testDeliveryPolicyByStartSeq(): void
+    {
+        $api = $this->getClient()
+            ->skipInvalidMessages(true)
+            ->getApi();
+
+        $stream = $api->getStream('my_stream');
+
+        $stream->getConfiguration()
+            ->setRetentionPolicy(RetentionPolicy::LIMITS)
+            ->setStorageBackend(StorageBackend::MEMORY)
+            ->setSubjects(['tester.hi', 'tester.bye']);
+
+        $stream->create();
+        $stream->put('tester.hi', 'hi'); # this message will be skipped because of delivery policy
+        $stream->put('tester.bye', 'bye');
+
+        $consumer = $stream->getConsumer('my_consumer')
+            ->setIterations(1)
+            ->setBatching(1)
+            ->setExpires(1.0);
+        $consumer->getConfiguration()
+            ->setDeliverPolicy(DeliverPolicy::BY_START_SEQUENCE)
+            ->setOptStartSeq(2);
+        $consumer->create();
+
+        $handled = false;
+        $consumer->handle(function (Payload $payload) use (&$handled) {
+            $this->assertSame('tester.bye', $payload->subject);
+            $this->assertSame('bye', $payload->body);
+            $handled = true;
+        });
+
+        $this->assertTrue($handled, 'Message was not handled.');
+    }
+
+    public function testDeliveryPolicyByStartTime(): void
+    {
+        $api = $this->getClient()
+            ->skipInvalidMessages(true)
+            ->getApi();
+
+        $stream = $api->getStream('my_stream');
+
+        $stream->getConfiguration()
+            ->setRetentionPolicy(RetentionPolicy::LIMITS)
+            ->setStorageBackend(StorageBackend::MEMORY)
+            ->setSubjects(['tester.hi']);
+
+        $stream->create();
+        $stream->put('tester.hi', 'hi'); # this message will be skipped because of delivery policy
+
+        sleep(1); # sleep to have some difference between message timestamps
+        $time = new DateTime();
+        $stream->put('tester.hi', 'Hey!!!');
+        $consumer = $stream->getConsumer('my_consumer')
+            ->setIterations(1)
+            ->setBatching(1)
+            ->setExpires(1.0);
+        $consumer->getConfiguration()
+            ->setDeliverPolicy(DeliverPolicy::BY_START_TIME)
+            ->setOptStartTime($time);
+        $consumer->create();
+
+        $handled = false;
+        $consumer->handle(function (Payload $payload) use (&$handled) {
+            $this->assertSame('tester.hi', $payload->subject);
+            $this->assertSame('Hey!!!', $payload->body);
+            $handled = true;
+        });
+
+        $this->assertTrue($handled, 'Message was not handled.');
+    }
+}

--- a/tests/Functional/DeliveryPolicyTest.php
+++ b/tests/Functional/DeliveryPolicyTest.php
@@ -36,7 +36,7 @@ class DeliveryPolicyTest extends FunctionalTestCase
             ->setExpires(1.0);
         $consumer->getConfiguration()
             ->setDeliverPolicy(DeliverPolicy::BY_START_SEQUENCE)
-            ->setOptStartSeq(2);
+            ->setStartSequence(2);
         $consumer->create();
 
         $handled = false;
@@ -74,7 +74,7 @@ class DeliveryPolicyTest extends FunctionalTestCase
             ->setExpires(1.0);
         $consumer->getConfiguration()
             ->setDeliverPolicy(DeliverPolicy::BY_START_TIME)
-            ->setOptStartTime($time);
+            ->setStartTime($time);
         $consumer->create();
 
         $handled = false;

--- a/tests/Functional/DeliveryPolicyTest.php
+++ b/tests/Functional/DeliveryPolicyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional;


### PR DESCRIPTION
There are two delivery policies for JetStream consumers which require additional options (`DeliveryPolicy::BY_START_SEQUENCE` and `DeliveryPolicy::BY_START_TIME`)

This PR adds setters for those options.