### PR TITLE
feat: check read timeout

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -299,7 +299,7 @@ class Client
                 if ($message->length) {
                     $iteration = 0;
                     while (strlen($payload) < $message->length) {
-                        $line = $this->readLine($message->length, checkTimeout: false);
+                        $line = $this->readLine($message->length, '', false);
                         if (!$line) {
                             if ($iteration > 16) {
                                 $exception = new LogicException("No payload for message $message->sid");

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -15,6 +15,19 @@ class ClientTest extends FunctionalTestCase
         $this->assertTrue($this->createClient()->ping());
     }
 
+    public function testConnectionTimeout(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Socket read timeout');
+
+        $client = $this->createClient([
+            'reconnect' => false,
+        ]);
+        $this->assertTrue($client->ping());
+
+        $client->process(1);
+    }
+
     public function testReconnect()
     {
         $client = $this->getClient();


### PR DESCRIPTION
This PR add additional read timeout check and throw exception if client didn't receive any data from NATS too long.
Why this check is important?

I'm using NATS with JetStream and in rare cases I run into situation when NATS doesn't send any data. To catch situation like this there should be few factors:
- There are no messages to read in the stream and message request timeout is not reached (no request timeout message from NATS)
- Ping time is not reached on the server side so client does not receive `PING` message
- Ping time is not reached on the client side so client does not send `PING` message and does not receive `PONG` message OR client send `PING` message but does not receive `PONG` message in time because of delay.

When all conditions are met client fails to read any data from socket (`stream_get_meta_data` shows that flag `timed_out` is true). Current client implementation will try to read data again and again  and will send `PING` to the server from time to time but socket is not closed. Client is able to write `PING\r\n` string into the socket (`fwrite` returns 6 as a result) but will never receive `PONG` response. This situation leads to infinite read loop.

This PR allows to break this loop and reconnect or just throw exception depending on client configuration.

ps. It is possible to avoid described problem with better ping interval and socket timeout configuration but this PR prevents this problem from appearance at all.