### PR TITLE
feat: do not call empty handler on ping message

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -271,7 +271,12 @@ class Client
         switch (trim($line)) {
             case 'PING':
                 $this->logger?->debug('receive ' . $line);
-                return $this->send(new Pong([]));
+                $this->send(new Pong([]));
+                $now = microtime(true);
+                if ($now >= $max) {
+                    return null;
+                }
+                return $this->process($max - $now);
 
             case 'PONG':
                 $this->logger?->debug('receive ' . $line);

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -144,7 +144,7 @@ class Consumer
                 break;
             }
 
-            if ($iteration && $runtime->empty) {
+            if ($iteration && $runtime->empty && !$expires) {
                 usleep((int) floor($this->getDelay() * 1_000_000));
             }
         }


### PR DESCRIPTION
This PR improves jet stream message processing removing redundant sleep when ping message was received or message request was expired