### PR TITLE
Enable on-demand consumer update

### DIFF
--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -41,6 +41,11 @@ class Consumer
         return $this;
     }
 
+    public function update(): self
+    {
+        return $this->create(false);
+    }
+
     public function delete(): self
     {
         $this->client->api('CONSUMER.DELETE.' . $this->getStream() . '.' . $this->getName());

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -195,6 +195,6 @@ class Consumer
     private function shouldCreateConsumer(bool $ifNotExists): bool
     {
         return ($this->configuration->isEphemeral() && $this->configuration->getName() === null)
-            || !$this->exists();
+            || !$this->exists() || !$ifNotExists;
     }
 }


### PR DESCRIPTION
cc @nekufa 

i can confirm `CONSUMER.CREATE` api updates existing consumers

this PR enables updating such consumers on-demand using `create(false)`, eg. when config has changed in code

it seems this feature was intially forgotten when developing the client, because the needed argument was already there :)
