### PR TITLE
[Tests fix]: Add retries for getting of 'num_pending'

### DIFF
--- a/tests/Functional/SubjectTest.php
+++ b/tests/Functional/SubjectTest.php
@@ -11,6 +11,7 @@ use Tests\FunctionalTestCase;
 
 class SubjectTest extends FunctionalTestCase
 {
+    private int $responseCounter = 0;
     public function testPublishSubscribe()
     {
         $this->tested = false;


### PR DESCRIPTION
getting value of _**num_pending**_ immediately after publish may returns wrong value.
Added retries for getting of 'num_pending'
Existing delays (_usleep_) in code were not deleted.
