### PR TITLE
WIP: add async client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "description": "nats jetstream client for php",
     "keywords": ["nats", "client", "streaming", "jetstream", "queue", "messaging", "subscribe", "publish", "request", "response", "bucket", "key-value", "storage"],
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "amphp/parser": "^1.1",
+        "amphp/socket": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -14,7 +16,9 @@
     },
     "suggest": {
         "paragonie/sodium_compat": "Provides Ed25519 for nkey authentication if sodium is not available",
-        "ext-sodium": "Provides Ed25519 for nkey authentication"
+        "ext-sodium": "Provides Ed25519 for nkey authentication",
+        "amphp/parser": "Provides async parsing of messages",
+        "amphp/socket": "Provides support for the async client"
     },
     "license": "mit",
     "autoload": {

--- a/src/Async/Parser.php
+++ b/src/Async/Parser.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Basis\Nats\Async;
+
+use Amp\Pipeline\Queue;
+
+class Parser extends \Amp\Parser\Parser {
+    private const CRLF = "\r\n";
+
+    public function __construct(Queue $queue)
+    {
+        parent::__construct(self::parser($queue));
+    }
+
+    private static function parser(Queue $queue): \Generator {
+        while(true) {
+            try {
+                $line = yield self::CRLF;
+
+                if(str_starts_with($line, 'MSG')) {
+                    $payload = yield self::CRLF;
+                    $queue->push([$line, $payload]);
+                    continue;
+                }
+
+                $queue->push($line);
+            } catch(\Throwable $exception) {
+                // todo: handle exception?
+                throw $exception;
+            }
+        }
+    }
+}

--- a/src/Async/Socket.php
+++ b/src/Async/Socket.php
@@ -70,6 +70,10 @@ class Socket
         });
     }
 
+    public function isAsync(): bool {
+        return $this->async;
+    }
+
     public function switchToSync() {
         $this->queue = $queue = new Queue();
 

--- a/src/Async/Socket.php
+++ b/src/Async/Socket.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Basis\Nats\Async;
+
+use Amp\CancelledException;
+use Amp\Pipeline\ConcurrentIterator;
+use Amp\Pipeline\Queue;
+use Amp\TimeoutCancellation;
+use Basis\Nats\Message\Factory;
+use Basis\Nats\Message\Msg;
+use Basis\Nats\Message\Prototype;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Revolt\EventLoop;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class Socket
+{
+    private ConcurrentIterator $iterator;
+    private Queue $queue;
+    private Parser $parser;
+
+    private bool $async = false;
+
+    public function __construct(
+        private readonly \Amp\Socket\Socket $socket,
+        private readonly LoggerInterface $logger = new NullLogger(),
+        private readonly \Closure|null $onPing = null,
+        private readonly \Closure|null $onPong = null,
+    ) {
+        $this->queue = $queue = new Queue();
+
+        $this->iterator = $queue->iterate();
+        $this->parser = new Parser($this->queue);
+
+        EventLoop::queue(function () use ($socket) {
+            try {
+                while (null !== $chunk = $socket->read()) {
+                    $this->parser->push($chunk);
+                }
+
+                $this->parser->cancel();
+                $this->queue->complete();
+            } catch (\Throwable $exception) {
+                // todo: handle exception
+                throw $exception;
+            } finally {
+                $socket->close();
+            }
+        });
+    }
+
+    public function switchToAsync(int $concurrency, \Closure $closure) {
+        if($this->async) {
+            return ;
+        }
+        $this->async = true;
+        $this->queue = new Queue();
+        $this->parser = new Parser($this->queue);
+        EventLoop::queue(function () use ($closure, $concurrency) {
+            foreach (
+                $this->queue->pipe()
+                    ->concurrent($concurrency)
+                    ->map($this->handleLine(...))
+                    ->map($closure(...)) as $_
+            ) {
+            }
+        });
+    }
+
+    public function switchToSync() {
+        $this->queue = $queue = new Queue();
+
+        $this->iterator = $queue->iterate();
+        $this->parser = new Parser($this->queue);
+    }
+
+    public function read(int|float|null $timeout = null, bool $reply = true): Prototype|null
+    {
+        $cancellation = null;
+        if ($timeout) {
+            $cancellation = new TimeoutCancellation($timeout, 'Operation timed out');
+        }
+
+        try {
+            if (!$this->iterator->continue($cancellation)) {
+                return null;
+            }
+        } catch (CancelledException $exception) {
+            $this->logger->debug("timed out waiting for message: ", ['exception' => $exception]);
+            return null;
+        }
+
+        $line = $this->iterator->getValue();
+
+        if (!($result = $this->handleLine($line))) {
+            return $this->read($timeout, $reply);
+        }
+
+        return $result;
+    }
+
+    private function handleLine(\Throwable|string|array $line): Prototype|null
+    {
+        if ($line instanceof \Throwable) {
+            throw $line;
+        }
+
+        if(is_array($line)) {
+            [$line, $payload] = $line;
+        }
+
+        // handle ping/pongs here, notify the owner of this socket, then wait for the next message
+        switch (trim($line)) {
+            case 'PING':
+                $this->logger->debug("Receive: $line");
+                $this->write("PONG");
+                ($this->onPing ?? static fn() => null)();
+                return null;
+            case 'PONG':
+                $this->logger->debug("Receive: $line");
+                ($this->onPong ?? static fn() => null)();
+                return null;
+            case '+OK':
+                $this->logger->debug("Message acknowledged");
+                return null;
+        }
+
+        try {
+            $result = Factory::create($line);
+            if($result instanceof Msg) {
+                return $result->parse($payload);
+            }
+            return $result;
+        } catch (\Throwable $exception) {
+            $this->logger->debug($line);
+            throw $exception;
+        }
+    }
+
+    public function write(string $line): void
+    {
+        // just throw the exception to be caught by the client, which is responsible for connection logic
+        $this->socket->write($line);
+    }
+
+    public function close(): void
+    {
+        $this->socket->close();
+    }
+
+    public function enableTls(): void
+    {
+        $this->socket->setupTls();
+    }
+
+    public function readArbitraryLine(int $assertLength): string|null
+    {
+        if (!$this->iterator->continue()) {
+            return null;
+        }
+
+        $line = $this->iterator->getValue();
+        if ($line instanceof \Throwable) {
+            throw $line;
+        }
+
+        if (($actualLenght = mb_strlen($line, '8bit')) !== $assertLength) {
+            throw new \RuntimeException('Expected payload of ' . $assertLength . ' bytes, but got ' . $actualLenght);
+        }
+
+        return $line;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->socket->isClosed();
+    }
+
+    public function __destruct()
+    {
+        $this->socket->close();
+    }
+}

--- a/src/AsyncClient.php
+++ b/src/AsyncClient.php
@@ -134,6 +134,9 @@ class AsyncClient extends Client
     }
 
     public function process(null|int|float $timeout = 0, bool $reply = true, bool $async = false): Info|null {
+        if($this->socket->isAsync()) {
+            return null;
+        }
         $this->lastDataReadFailureAt = null;
         $message = $this->socket->read($timeout, $reply);
         if($message === null) {

--- a/src/AsyncClient.php
+++ b/src/AsyncClient.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+namespace Basis\Nats;
+
+use Amp\Socket\Certificate;
+use Amp\Socket\ClientTlsContext;
+use Amp\Socket\ConnectContext;
+use Amp\TimeoutCancellation;
+use Basis\Nats\Async\Socket;
+use Basis\Nats\Message\Connect;
+use Basis\Nats\Message\Info;
+use Basis\Nats\Message\Msg;
+use Basis\Nats\Message\Ping;
+use Basis\Nats\Message\Prototype;
+use Phan\Language\Context;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+use Revolt\EventLoop;
+
+use function Amp\Socket\socketConnector;
+
+class AsyncClient extends Client
+{
+    public readonly Api $api;
+
+    private Socket $socket;
+
+    public function __construct(
+        Configuration $configuration = new Configuration(),
+        LoggerInterface|null $logger = new NullLogger(),
+    ) {
+        parent::__construct($configuration, $logger);
+    }
+
+    public function connect(): Client
+    {
+        if(isset($this->socket)) {
+            return $this;
+        }
+
+        $config = $this->configuration;
+        $dsn = "$config->host:$config->port";
+
+        try {
+            $context = (new ConnectContext())->withConnectTimeout($config->timeout);
+            $tlsContext = null;
+            if($config->tlsKeyFile || $config->tlsCertFile) {
+                $tlsContext ??= new ClientTlsContext();
+                $tlsContext = $tlsContext->withCertificate(new Certificate($config->tlsCertFile, $config->tlsKeyFile));
+            }
+            if($config->tlsCaFile) {
+                $tlsContext ??= new ClientTlsContext();
+                $tlsContext = $tlsContext->withCaFile($config->tlsCaFile);
+            }
+            if($tlsContext) {
+                $context = $context->withTlsContext($tlsContext);
+            }
+            $this->socket = new Socket(socketConnector()->connect($dsn, $context));
+        } catch(\Throwable $exception) {
+            // todo: handle exception
+            throw $exception;
+        }
+
+        $info = $this->process($config->timeout);
+        assert($info instanceof Info);
+
+        $connect = new Connect($config->getOptions());
+        if($this->name) {
+            $connect->name = $this->name;
+        }
+        if(isset($info->nonce) && $this->authenticator) {
+            $connect->sig = $this->authenticator->sign($info->nonce);
+            $connect->nkey = $this->authenticator->getPublicKey();
+        }
+
+        $this->send($connect);
+
+        return $this;
+    }
+
+    public function setTimeout(float $value): Client
+    {
+        throw new \LogicException('timeout is set via configuration');
+    }
+
+    public function ping():bool {
+        $this->send(new Ping([]));
+
+        // todo: handle this result better
+        return true;
+    }
+
+    public function background(bool $enableAutoReply, int $concurrency = 10): \Closure  {
+        $this->socket->switchToAsync($concurrency, fn(Prototype|null $message) => $message && $this->onMessage($message, $enableAutoReply, false));
+        return $this->socket->switchToSync(...);
+    }
+
+    private function onMessage(Prototype $message, bool $reply = true, bool $async = false): Info|null {
+        switch($message::class) {
+            case Info::class:
+                if(($message->tls_verify ?? false) || ($message->tls_required ?? false )) {
+                    $this->socket->enableTls();
+                }
+                return $message;
+            case Msg::class:
+                assert($message instanceof Msg);
+                $handler = $this->handlers[$message->sid] ?? null;
+                if(!$handler) {
+                    if($this->skipInvalidMessages) {
+                        return null;
+                    }
+                    throw new \LogicException('No handler for ' . $message->sid);
+                }
+
+                if($async) {
+                    EventLoop::queue(function () use ($handler, $message, $reply) {
+                        $result = $handler($message->payload, $message->replyTo);
+                        if ($reply && $message->replyTo) {
+                            $this->publish($message->replyTo, $result);
+                        }
+                    });
+                } else {
+                    $result = $handler($message->payload, $message->replyTo);
+                    if($reply && $message->replyTo) {
+                        $this->publish($message->replyTo, $result);
+                    }
+                }
+                break;
+        }
+
+        return null;
+    }
+
+    public function process(null|int|float $timeout = 0, bool $reply = true, bool $async = false): Info|null {
+        $this->lastDataReadFailureAt = null;
+        $message = $this->socket->read($timeout, $reply);
+        if($message === null) {
+            return null;
+        }
+
+        return $this->onMessage($message, $reply);
+    }
+
+    protected function send(Prototype $message): self {
+        $this->connect();
+
+        $line = $message->render() . "\r\n";
+
+        $this->socket->write($line);
+
+        return $this;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,18 +27,18 @@ class Client
     public Info $info;
     public readonly Api $api;
 
-    private readonly ?Authenticator $authenticator;
+    protected readonly ?Authenticator $authenticator;
 
     private $socket;
     private $context;
-    private array $handlers = [];
+    protected array $handlers = [];
     private float $ping = 0;
     private float $pong = 0;
-    private ?float $lastDataReadFailureAt = null;
-    private string $name = '';
+    protected ?float $lastDataReadFailureAt = null;
+    protected string $name = '';
     private array $subscriptions = [];
 
-    private bool $skipInvalidMessages = false;
+    protected bool $skipInvalidMessages = false;
 
     public function __construct(
         public readonly Configuration $configuration = new Configuration(),
@@ -439,7 +439,7 @@ class Client
         return $this;
     }
 
-    private function send(Prototype $message): self
+    protected function send(Prototype $message): self
     {
         $this->connect();
 

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -14,6 +14,9 @@ abstract class FunctionalTestCase extends TestCase
 
     public function createClient(array ...$options): Client
     {
+        $class = $options[0]['client'] ?? Client::class;
+        unset($options[0]['client']);
+
         $configuration = $this->getConfiguration(...$options);
 
         $logger = null;
@@ -21,7 +24,7 @@ abstract class FunctionalTestCase extends TestCase
             $logger = $this->getLogger();
         }
 
-        return new Client($configuration, $logger);
+        return new $class($configuration, $logger);
     }
 
     protected ?Client $client = null;

--- a/tests/Performance/AsyncPerformanceTest.php
+++ b/tests/Performance/AsyncPerformanceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+
+use Tests\FunctionalTestCase;
+
+class AsyncPerformanceTest extends FunctionalTestCase
+{
+    private int $limit = 100_000;
+    private int $counter = 0;
+
+    public function testBackgroundPerformance()
+    {
+        /** @var \Basis\Nats\AsyncClient $client */
+        $client = $this->createClient(['client' => \Basis\Nats\AsyncClient::class])->setDelay(0);
+        $client->setLogger(new \Psr\Log\NullLogger());
+
+        $this->logger?->info('start performance test');
+        [$left, $right] = \Amp\Sync\createChannelPair();
+
+        $client->subscribe('hello-async', function ($n) use ($left) {
+            $this->counter++;
+            if($this->counter === $this->limit) {
+                $left->send('done');
+            }
+        });
+
+        $publishing = microtime(true);
+        foreach (range(1, $this->limit) as $n) {
+            $client->publish('hello-async', 'data-' . $n);
+        }
+        $publishing = microtime(true) - $publishing;
+
+        $this->logger?->info('publishing', [
+            'rps' => floor($this->limit / $publishing),
+            'length' => $this->limit,
+            'time' => $publishing,
+        ]);
+
+        $stop = $client->background(true, 5);
+
+        $processing = microtime(true);
+        $right->receive();
+        $processing = microtime(true) - $processing;
+
+        $stop();
+
+        $this->logger?->info('processing', [
+            'rps' => floor($this->limit / $processing),
+            'length' => $this->limit,
+            'finished' => $this->counter,
+            'time' => $processing,
+        ]);
+
+        // at least 5000rps should be enough for test
+        $this->assertGreaterThan(5000, $this->limit / $processing);
+    }
+
+    public function testForegroundPerformance()
+    {
+        /** @var \Basis\Nats\AsyncClient $client */
+        $client = $this->createClient(['client' => \Basis\Nats\AsyncClient::class])->setDelay(0);
+        $client->setLogger(new \Psr\Log\NullLogger());
+
+        $this->logger?->info('start performance test');
+
+        $client->subscribe('hello-async', function ($n) {
+            $this->counter++;
+        });
+
+        $publishing = microtime(true);
+        foreach (range(1, $this->limit) as $n) {
+            $client->publish('hello-async', 'data-' . $n);
+        }
+        $publishing = microtime(true) - $publishing;
+
+        $this->logger?->info('publishing', [
+            'rps' => floor($this->limit / $publishing),
+            'length' => $this->limit,
+            'time' => $publishing,
+        ]);
+
+        $processing = microtime(true);
+        while ($this->counter < $this->limit) {
+            $client->process(0);
+        }
+        $processing = microtime(true) - $processing;
+
+        $this->logger?->info('processing', [
+            'rps' => floor($this->limit / $processing),
+            'length' => $this->limit,
+            'finished' => $this->counter,
+            'time' => $processing,
+        ]);
+
+        // at least 5000rps should be enough for test
+        $this->assertGreaterThan(5000, $this->limit / $processing);
+    }
+}


### PR DESCRIPTION
This PR adds an async client (using amphp). First, take a look at the performance:

| mode | pubs per sec | recv per sec |
| --- |  ---  | ---- |
| async (background) | 236,660 | 40,233 |
| async (foreground) | 303,717 | 110,119 |
| sync | 319,977 | 238,854 |

Async takes a HUGE performance hit, but it allows you to do other things while things are processing. So, this is a trade-off: less throughput for more flexibility.

Using it:

```php
// this should be almost exactly the same
$client = new AsyncClient($config);
$client->subscribe('hello', $callback);

$stop = $client->background(enableAutoReply: true, concurrency: 10);

try {
  // or whatever you want to do here, but you need to yield to the event loop
  // to run the client, or do other async things.
  $bucket = $client->api->getBucket('bucket');
  $entry = $bucket->getEntry('key');

  // but if you don't have anything left to do, you MUST yield to the event loop at some point.
  EventLoop::run();
} finally {
  $stop();
}

// or you can process as usual
$client->process();
```

This is still a work in progress, but I'd love to know if you are interested in merging this.