### PR TITLE
Expose handler result

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -338,7 +338,7 @@ class Client
                 if ($reply && $message->replyTo) {
                     $this->publish($message->replyTo, $result);
                 }
-                break;
+                return $result;
         }
     }
 


### PR DESCRIPTION
Hi,

We don't run our handlers within `Consumer::handle` scope, instead we'd like to subscribe, yield N messages to the outside, then unsubscribe.

This is currenly impossible as we dont get the handler result back from `process()`

This enables doing eg.:

```
subscribe(fn () => message)
yield process()
unsubscribe()
```

cc @nekufa 
