### PR TITLE
fix uninitialized payload property

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -317,6 +317,8 @@ class Client
             }
 
             $message->parse($payload);
+        } elseif ($message instanceof Msg) {
+            $message->parse($payload);
         }
 
         $this->logger?->debug('receive ' . $line . $payload);


### PR DESCRIPTION
we use `dispatch()` for manual acking

i assume it's a proper client usage, since it fully handles response processing

i noticed for empty ack responses we get


```
In Client.php line 346:
                                                                                              
  [Error]                                                                                     
  Typed property Basis\Nats\Message\Msg::$payload must not be accessed before initialization  
                                                                                              

Exception trace:
  at /app/vendor/basis-company/nats/src/Client.php:346
 Basis\Nats\Client->onMessage() at /app/vendor/basis-company/nats/src/Client.php:325
 Basis\Nats\Client->process() at /app/vendor/basis-company/nats/src/Client.php:177
 Basis\Nats\Client->request() at /app/vendor/basis-company/nats/src/Client.php:129
```

this solves it

cc @nekufa :)