### PR TITLE
fix error checking

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -47,7 +47,7 @@ class Client
 
         $result = $this->dispatch($subject, $options);
 
-        if (property_exists($result, 'error')) {
+        if ($result->error ?? false) {
             throw new Exception($result->error->description, $result->error->err_code);
         }
 


### PR DESCRIPTION
took me some time to realize stream was missing due underlying error

```
"error":{"code":400,"err_code":10005,"description":"no suitable peers for placement"}
```

but this never threw, now it does :)

for future reference: never use php magic methods :)