### PR TITLE
Fix typo in README.md variable reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ $greeter->handle(function ($address) {
     mail($address, "Hi there!");
 });
 
-var_dump($greater->info()); // can consumer info
+var_dump($greeter->info()); // can consumer info
 
 $goodbyer = $stream->getConsumer('goodbyer');
 $goodbyer->getConfiguration()->setSubjectFilter('mailer.bye');


### PR DESCRIPTION
Corrected a typo in the variable name within the code example in the README documentation, ensuring consistency and preventing confusion for readers following the example. The typo fix changes 'greater' to 'greeter' in the variable dump line.