### PR TITLE
Add PURGE stream

### DIFF
--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -42,6 +42,15 @@ class Stream
         return $this;
     }
 
+    public function purge(): self
+    {
+        if ($this->exists()) {
+            $this->client->api("STREAM.PURGE." . $this->getName());
+        }
+
+        return $this;
+    }
+
     public function exists(): bool
     {
         return in_array($this->getName(), $this->client->getApi()->getStreamNames());


### PR DESCRIPTION
Added $JS.API.STREAM.PURGE.* - "Purges all of the data in a Stream, leaves the Stream"

purgeQueue is one of the [queue-interop](https://github.com/queue-interop/queue-interop) operations on queue

```php
public function purgeQueue(Queue $queue): void;
```

Adding PURGE will improve functionality of NatsJS transport (in development) in [php-enqueue](https://github.com/php-enqueue/enqueue) (implementation of queue-interop) 