### PR TITLE
Add option to unsubscribe consumers and close connection 

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -20,6 +20,7 @@ class Client
 
     private string $name = '';
 
+    /** @var array<Closure|Queue> */
     private array $handlers = [];
     private array $subscriptions = [];
 
@@ -238,6 +239,25 @@ class Client
     public function skipInvalidMessages(bool $skipInvalidMessages): self
     {
         $this->skipInvalidMessages = $skipInvalidMessages;
+        return $this;
+    }
+
+    public function unsubscribeAll(): self
+    {
+        foreach ($this->subscriptions as $index => $subscription) {
+            unset($this->subscriptions[$index]);
+            $this->connection->sendMessage(new Unsubscribe(['sid' => $subscription['sid']]));
+            unset($this->handlers[$subscription['sid']]);
+        }
+
+        return $this;
+    }
+
+    public function disconnect(): self
+    {
+        $this->unsubscribeAll();
+        $this->connection->close();
+
         return $this;
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -290,4 +290,12 @@ class Connection
             ]));
         }
     }
+
+    public function close(): void
+    {
+        if ($this->socket) {
+            fclose($this->socket);
+            $this->socket = null;
+        }
+    }
 }

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -112,4 +112,21 @@ class ClientTest extends FunctionalTestCase
         ]);
         $client->ping();
     }
+
+    public function testCloseClosesSocket(): void
+    {
+        $client = $this->createClient([]);
+        self::assertTrue($client->ping());
+
+        $connection = $client->connection;
+
+        // Call the close method
+        $connection->close();
+
+        $property = new ReflectionProperty(Connection::class, 'socket');
+        $property->setAccessible(true);
+
+        // Assert that the socket is closed and set to null
+        self::assertNull($property->getValue($connection));
+    }
 }


### PR DESCRIPTION
Fixes basis-company/nats.php/#30

Created this issue since we also need to be able to close the connection in environments where php as is run as a daemon