### PR TITLE
fix ack payload rendering

### DIFF
--- a/src/Message/Msg.php
+++ b/src/Message/Msg.php
@@ -77,12 +77,9 @@ class Msg extends Prototype
 
     public function nack(float $delay = 0): void
     {
-        $this->reply(new Ack([
-            'command' => '-NAK',
+        $this->reply(new Nak([
             'subject' => $this->replyTo,
-            'payload' => Payload::parse([
-                'delay' => $delay,
-            ]),
+            'delay' => $delay,
         ]));
     }
 
@@ -125,8 +122,7 @@ class Msg extends Prototype
 
     public function progress(): void
     {
-        $this->reply(new Ack([
-            'command' => '+WPI',
+        $this->reply(new Progress([
             'subject' => $this->replyTo,
         ]));
     }

--- a/src/Message/Nak.php
+++ b/src/Message/Nak.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Basis\Nats\Message;
+
+class Nak extends Prototype
+{
+    public string $subject;
+    public float $delay;
+
+    public function render(): string
+    {
+        $data = ['-NAK'];
+        if (isset($this->delay) && $this->delay > 0) {
+            $data[] = json_encode(['delay' => $this->delay * 10 ** 9]);
+        }
+        $payload = Payload::parse(implode(' ', $data))->render();
+        return "PUB $this->subject  $payload";
+    }
+}

--- a/src/Message/Progress.php
+++ b/src/Message/Progress.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Basis\Nats\Message;
 
-class Ack extends Prototype
+class Progress extends Prototype
 {
     public string $subject;
 
     public function render(): string
     {
-        $payload = Payload::parse('')->render();
+        $payload = Payload::parse('+WPI')->render();
         return "PUB $this->subject  $payload";
     }
 }

--- a/tests/Functional/StreamTest.php
+++ b/tests/Functional/StreamTest.php
@@ -44,7 +44,7 @@ class StreamTest extends FunctionalTestCase
         $message = $queue->fetch();
         $this->assertNotNull($message);
         $this->assertSame((string) $message->payload, 'first');
-        $message->nack(1);
+        $message->nack(30);
 
         $this->assertSame(1, $consumer->info()->num_ack_pending);
         $this->assertSame(1, $consumer->info()->num_pending);

--- a/tests/Unit/Message/AckTest.php
+++ b/tests/Unit/Message/AckTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Message;
+
+use Basis\Nats\Message\Ack;
+use Tests\TestCase;
+
+class AckTest extends TestCase
+{
+    public function testAck()
+    {
+        $ack = new Ack([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0'
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  0\r\n", $ack->render());
+    }
+
+}

--- a/tests/Unit/Message/NakTest.php
+++ b/tests/Unit/Message/NakTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Message;
+
+use Basis\Nats\Message\Nak;
+use Tests\TestCase;
+
+class NakTest extends TestCase
+{
+    public function testNak()
+    {
+        $nak = new Nak([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0'
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  4\r\n-NAK", $nak->render());
+    }
+
+    public function testNakDelay()
+    {
+        $nak = new Nak([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0',
+            'delay' => 10
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  26\r\n-NAK {\"delay\":10000000000}", $nak->render());
+    }
+
+    public function testNakFloatDelay()
+    {
+        $nak = new Nak([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0',
+            'delay' => 1.1
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  25\r\n-NAK {\"delay\":1100000000}", $nak->render());
+    }
+    public function testNakZeroDelay()
+    {
+        $nak = new Nak([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0',
+            'delay' => 0
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  4\r\n-NAK", $nak->render());
+    }
+}

--- a/tests/Unit/Message/ProgressTest.php
+++ b/tests/Unit/Message/ProgressTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Message;
+
+use Basis\Nats\Message\Progress;
+use Tests\TestCase;
+
+class ProgressTest extends TestCase
+{
+    public function testProgress()
+    {
+        $progress = new Progress([
+            'subject' => '$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0'
+        ]);
+
+        $this->assertEquals("PUB \$JS.ACK.stream.consumer.1.3.18.1719992702186105579.0  4\r\n+WPI", $progress->render());
+    }
+
+}


### PR DESCRIPTION
Currently the payload generated to publish a NAK is wrong and does not result of actually nak-ing a message. 

According to the documentation, acknowledgment is done only by sending the reply string, but Ack prorotype here generates adds +ACK command in the payload
it results in a mesasge like this
``PUB $JS.ACK.sample-stream.psub.3.1.21.1719946162089866350.0  +ACK 0``
but the actual that is required is this
``PUB $JS.ACK.sample-stream.psub.3.1.21.1719946162089866350.0  0``

When generating NAKs, the problem continues. It generates a message like this 
``PUB $JS.ACK.sample-stream.psub.3.1.21.1719946162089866350.0  -NAK 21\r\n{"delay": 5000000000}``
but the expexted nack string is 
``PUB $JS.ACK.sample-stream.psub.2.1.11.1719946162089866350.0  26\r\n-NAK {"delay": 5000000000}``

The -NAK command is required to be part of the body and included in the lenght of the message, not before the length.
Here are some samples from the Python library that i've traced 
```
b'PUB $JS.ACK.sample-stream.psub.3.1.21.1719946162089866350.0  0\r\n\r\n'
b'PUB $JS.ACK.sample-stream.psub.1.1.1.1719946162089866350.9  4\r\n-NAK\r\n'
b'PUB $JS.ACK.sample-stream.psub.2.1.11.1719946162089866350.0  26\r\n-NAK {"delay": 5000000000}\r\n'
b'PUB $JS.ACK.sample-stream.psub.4.1.31.1719946162089866350.0  4\r\n+WPI\r\n'
```

With the issue above, when you try to nak a mesage with delay, message is always delayed only 30s which is not the actual delay but the default AckWait for the consumer.

With the current PR the issue should be fixed 