### PR TITLE
Improve performance for large payloads

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -28,7 +28,7 @@ class Connection
     private float $pingAt = 0;
     private float $pongAt = 0;
     private float $prolongateTill = 0;
-    private int $paketSize = 1024;
+    private int $packetSize = 1024;
 
     private ?Authenticator $authenticator;
     private Configuration $config;
@@ -135,7 +135,7 @@ class Connection
 
         while ($total < $length) {
             try {
-                $written = @fwrite($this->socket, substr($line, $total, $this->paketSize));
+                $written = @fwrite($this->socket, substr($line, $total, $this->packetSize));
                 if ($written === false) {
                     throw new LogicException('Error sending data');
                 }
@@ -298,7 +298,7 @@ class Connection
 
     public function setPacketSize(int $size): void
     {
-        $this->paketSize = $size;
+        $this->packetSize = $size;
     }
 
     public function close(): void

--- a/tests/Performance/PerformanceTest.php
+++ b/tests/Performance/PerformanceTest.php
@@ -10,6 +10,8 @@ class PerformanceTest extends FunctionalTestCase
 {
     private int $limit = 500_000;
     private int $counter = 0;
+    private int $bigMessageIterationLimit = 1000;
+    private int $payloadSize = 1024 * 450; // 900kb
 
     public function testPerformance()
     {
@@ -48,5 +50,30 @@ class PerformanceTest extends FunctionalTestCase
 
         // at least 5000rps should be enough for test
         $this->assertGreaterThan(5000, $this->limit / $processing);
+    }
+
+
+    public function testPerformanceWithBigMessages()
+    {
+        $client = $this->createClient()->setTimeout(0.1)->setDelay(0);
+        $client->connection->setLogger(null);
+
+        $bigPayload = bin2hex(random_bytes($this->payloadSize));
+        $this->logger?->info('start big message performance test with size: '. strlen($bigPayload) / 1024 .'kb');
+
+        $publishing = microtime(true);
+        for ($i = 0; $i < $this->bigMessageIterationLimit; $i++) {
+            $client->publish('hello', $bigPayload);
+        }
+        $publishing = microtime(true) - $publishing;
+
+        $this->logger?->info('publishing', [
+            'rps' => floor($this->bigMessageIterationLimit / $publishing),
+            'length' => $this->bigMessageIterationLimit,
+            'time' => $publishing,
+        ]);
+
+        // at least 50rps should be enough for test
+        $this->assertGreaterThan(500, $this->bigMessageIterationLimit / $publishing);
     }
 }


### PR DESCRIPTION
During a try to implement Object store around this lib, me and my team stumbled on a performance issue. Trying to substring from few hundred kilobytes worth of text was quite heavy and was slowing down the push quite a lot. 
Here is the performance test done with the old substring: 
```
[docker://php-8.1-cli:latest/]:php /opt/project/vendor/phpunit/phpunit/phpunit --configuration /opt/project/phpunit.xml.dist --filter "/(Tests\\Performance\\PerformanceTest::testPerformanceWithBigMessages)( .*)?$/" --test-suffix PerformanceTest.php /opt/project/tests/Performance --teamcity
Testing started at 15:45 ...
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.29
Configuration: /opt/project/phpunit.xml.dist
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

[2024-10-14T12:45:42.982127+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive INFO {"server_id":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","server_name":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","version":"2.10.21","proto":1,"git_commit":"d3a8868","go":"go1.22.7","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"jetstream":true,"client_id":102961,"client_ip":"192.168.97.1","cluster":"test-cluster","xkey":"XA5AJ5IFPZSDILV5PMHHWQUR56OIF3ONNKXS5ZCT6ZKOMGNOVM2S5AK2"}  [] []
[2024-10-14T12:45:42.983074+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send CONNECT {"headers":true,"pedantic":false,"verbose":false,"lang":"php","version":"dev"}  [] []
[2024-10-14T12:45:42.984239+00:00] PerformanceTest.testPerformanceWithBigMessages.INFO: start big message performance test with size: 900kb [] []
[2024-10-14T12:45:51.354511+00:00] PerformanceTest.testPerformanceWithBigMessages.INFO: publishing {"rps":119.0,"length":1000,"time":8.370211124420166} []
[2024-10-14T12:45:51.359007+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive INFO {"server_id":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","server_name":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","version":"2.10.21","proto":1,"git_commit":"d3a8868","go":"go1.22.7","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"jetstream":true,"client_id":102962,"client_ip":"192.168.97.1","cluster":"test-cluster","xkey":"XA5AJ5IFPZSDILV5PMHHWQUR56OIF3ONNKXS5ZCT6ZKOMGNOVM2S5AK2"}  [] []
[2024-10-14T12:45:51.359052+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send CONNECT {"headers":true,"pedantic":false,"verbose":false,"lang":"php","version":"dev"}  [] []
[2024-10-14T12:45:51.359110+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send SUB _INBOX.d69934d1b52cfb9b63cdeb09a254e31b dd1a3cb8  [] []
[2024-10-14T12:45:51.359185+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send PUB $JS.API.STREAM.NAMES _INBOX.d69934d1b52cfb9b63cdeb09a254e31b 2 {}  [] []
[2024-10-14T12:45:51.359767+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive MSG _INBOX.d69934d1b52cfb9b63cdeb09a254e31b dd1a3cb8 106{"type":"io.nats.jetstream.api.v1.stream_names_response","total":0,"offset":0,"limit":1024,"streams":null} [] []
[2024-10-14T12:45:51.359955+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send UNSUB dd1a3cb8  [] []

Failed asserting that 119.47129948520546 is greater than 500.
 /opt/project/tests/Performance/PerformanceTest.php:77
 


Time: 00:08.398, Memory: 10.00 MB


FAILURES!
Tests: 1, Assertions: 1, Failures: 1.

Process finished with exit code 1

```
Which for 1k iterations with 900k payload it was taking 8 seconds to finish. 
And here is the changed one 
```


[docker://php-8.1-cli:latest/]:php /opt/project/vendor/phpunit/phpunit/phpunit --configuration /opt/project/phpunit.xml.dist --filter "/(Tests\\Performance\\PerformanceTest::testPerformanceWithBigMessages)( .*)?$/" --test-suffix PerformanceTest.php /opt/project/tests/Performance --teamcity
Testing started at 15:43 ...
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.29
Configuration: /opt/project/phpunit.xml.dist
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

[2024-10-14T12:43:56.129222+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive INFO {"server_id":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","server_name":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","version":"2.10.21","proto":1,"git_commit":"d3a8868","go":"go1.22.7","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"jetstream":true,"client_id":102882,"client_ip":"192.168.97.1","cluster":"test-cluster","xkey":"XA5AJ5IFPZSDILV5PMHHWQUR56OIF3ONNKXS5ZCT6ZKOMGNOVM2S5AK2"}  [] []
[2024-10-14T12:43:56.129917+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send CONNECT {"headers":true,"pedantic":false,"verbose":false,"lang":"php","version":"dev"}  [] []
[2024-10-14T12:43:56.131529+00:00] PerformanceTest.testPerformanceWithBigMessages.INFO: start big message performance test with size: 900kb [] []
[2024-10-14T12:43:57.013051+00:00] PerformanceTest.testPerformanceWithBigMessages.INFO: publishing {"rps":1134.0,"length":1000,"time":0.881401777267456} []
[2024-10-14T12:43:57.015083+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive INFO {"server_id":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","server_name":"NBSTVVPB2TEHTQSDYO7RTRA7LPKPUWE7ZWTVWHWDO3SJOHJUF4X52RFR","version":"2.10.21","proto":1,"git_commit":"d3a8868","go":"go1.22.7","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"jetstream":true,"client_id":102956,"client_ip":"192.168.97.1","cluster":"test-cluster","xkey":"XA5AJ5IFPZSDILV5PMHHWQUR56OIF3ONNKXS5ZCT6ZKOMGNOVM2S5AK2"}  [] []
[2024-10-14T12:43:57.015134+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send CONNECT {"headers":true,"pedantic":false,"verbose":false,"lang":"php","version":"dev"}  [] []
[2024-10-14T12:43:57.015179+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send SUB _INBOX.93fa1fcb7b06ad5eb0d665dd0748cfff b00a9b9c  [] []
[2024-10-14T12:43:57.015243+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send PUB $JS.API.STREAM.NAMES _INBOX.93fa1fcb7b06ad5eb0d665dd0748cfff 2 {}  [] []
[2024-10-14T12:43:57.015729+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: receive MSG _INBOX.93fa1fcb7b06ad5eb0d665dd0748cfff b00a9b9c 106{"type":"io.nats.jetstream.api.v1.stream_names_response","total":0,"offset":0,"limit":1024,"streams":null} [] []
[2024-10-14T12:43:57.015804+00:00] PerformanceTest.testPerformanceWithBigMessages.DEBUG: send UNSUB b00a9b9c  [] []


Time: 00:00.895, Memory: 18.00 MB

OK (1 test, 1 assertion)

Process finished with exit code 0

```

Which took just 0.8 seconds to finish, which is 10 times faster. 