### PR TITLE
Added support for "compression" option in Jetstream & KV configurations

### DIFF
--- a/src/KeyValue/Configuration.php
+++ b/src/KeyValue/Configuration.php
@@ -14,6 +14,7 @@ class Configuration
     private ?int $maxValueSize = null;
     private ?int $replicas = null;
     private ?int $ttl = null;
+    private bool $compression = false;
 
     public function __construct(private readonly string $name)
     {
@@ -30,7 +31,9 @@ class Configuration
             ->setMaxMessageSize($this->getMaxValueSize())
             ->setMaxMessagesPerSubject($this->getHistory() ?? 1)
             ->setReplicas($this->getReplicas() ?? 1)
-            ->setSubjects(["\$KV.$this->name.*"]);
+            ->setSubjects(["\$KV.$this->name.*"])
+            ->setCompression($this->getCompression() ? "s2" : null)
+        ;
 
         return $this;
     }
@@ -60,6 +63,11 @@ class Configuration
         return $this->ttl;
     }
 
+    public function getCompression(): bool
+    {
+        return $this->compression;
+    }
+
     public function setHistory(?int $history): self
     {
         $this->history = $history;
@@ -87,6 +95,12 @@ class Configuration
     public function setTtl(?int $ttl): self
     {
         $this->ttl = $ttl;
+        return $this;
+    }
+
+    public function setCompression(bool $compression = true): self
+    {
+        $this->compression = $compression;
         return $this;
     }
 }

--- a/src/Stream/Configuration.php
+++ b/src/Stream/Configuration.php
@@ -8,22 +8,22 @@ use DomainException;
 
 class Configuration
 {
-    private array $subjects = [];
-    private bool $allowRollupHeaders = true;
-    private bool $denyDelete = true;
-    private int $maxAge = 0;
-    private int $maxConsumers = -1;
-    private int $replicas = 1;
-    private string $discardPolicy = DiscardPolicy::OLD;
-    private string $retentionPolicy = RetentionPolicy::LIMITS;
-    private string $storageBackend = StorageBackend::FILE;
-
-    private ?float $duplicateWindow = null;
-    private ?int $maxBytes = null;
-    private ?int $maxMessageSize = null;
-    private ?int $maxMessagesPerSubject = null;
+    private array   $subjects = [];
+    private bool    $allowRollupHeaders = true;
+    private bool    $denyDelete = true;
+    private int     $maxAge = 0;
+    private int     $maxConsumers = -1;
+    private int     $replicas = 1;
+    private string  $discardPolicy = DiscardPolicy::OLD;
+    private string  $retentionPolicy = RetentionPolicy::LIMITS;
+    private string  $storageBackend = StorageBackend::FILE;
+    private ?float  $duplicateWindow = null;
+    private ?int    $maxBytes = null;
+    private ?int    $maxMessageSize = null;
+    private ?int    $maxMessagesPerSubject = null;
     private ?string $description = null;
-    private ?array $consumerLimits = null;
+    private ?array  $consumerLimits = null;
+    private ?string $compression = null;
 
     public function __construct(
         public readonly string $name
@@ -116,6 +116,11 @@ class Configuration
         return $this->subjects;
     }
 
+    public function getCompression(): ?string
+    {
+        return $this->compression;
+    }
+
     public function setAllowRollupHeaders(bool $allowRollupHeaders): self
     {
         $this->allowRollupHeaders = $allowRollupHeaders;
@@ -203,6 +208,12 @@ class Configuration
         return $this;
     }
 
+    public function setCompression(?string $compression): self
+    {
+        $this->compression = $compression;
+        return $this;
+    }
+
     public function getConsumerLimits(): ?array
     {
         return $this->consumerLimits;
@@ -227,6 +238,7 @@ class Configuration
             'storage' => $this->getStorageBackend(),
             'subjects' => $this->getSubjects(),
             'consumer_limits' => $this->getConsumerLimits(),
+            'compression' => $this->getCompression(),
         ];
 
         foreach ($config as $k => $v) {


### PR DESCRIPTION
Added option for jetstream configuration to support compression in KV Store.

Compression added with nats 2.10.0+ and
KV Store, rev. 4 (2023-10-25)
Object Store, rev. 3 (2024-02-05)

https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-8.md