### PR TITLE
Add dot on requestsSubject and requestsSid

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -46,8 +46,8 @@ class Client
             $this->connection = new Connection(client: $this, logger: $logger);
         }
 
-        $this->requestsSubject = '_REQS' . bin2hex(random_bytes(16));
-        $this->requestsSid = '_REQS' . $this->getnextRid();
+        $this->requestsSubject = '_REQS.' . bin2hex(random_bytes(16));
+        $this->requestsSid = '_REQS.' . $this->getnextRid();
     }
 
     public function api($command, array $args = [], ?callable $callback = null): ?object


### PR DESCRIPTION
Adding a dot to the _REQS subject to become _REQS. to simplify granting subscribe permissions on the NATS server.

example permission : 
       {
            user:"user"
            password:"pass"
            permissions:{
                publish:{
                    allow:[]
                }
                subscribe:{
                    allow:["_INBOX.>","$SYS.>","_REQS.>"]
                }
            }
        }