### PR TITLE
Add new `api_lvl` property to Info message to support NATS Server 2.12

### DIFF
--- a/src/Message/Info.php
+++ b/src/Message/Info.php
@@ -35,6 +35,7 @@ class Info extends Prototype
     public ?string $ip;
     public ?string $nonce;
     public ?string $xkey;
+    public ?string $api_lvl;
 
     public function render(): string
     {


### PR DESCRIPTION
NATS 2.12 [introduces a new property](https://github.com/nats-io/nats-server/commit/778987ca9489c7012fdd8d622cfd864c3a1b82c4#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4) on the Info message: `api_lvl`. 

This commit/PR adds the property on the Info class to prevent the SDK from crashing when connecting to a NATS 2.12 server.

Fixes #117.