### PR TITLE
Fix issue 92.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -217,10 +217,10 @@ class Connection
         stream_set_timeout($this->socket, $seconds, $microseconds);
     }
 
-    protected function init()
+    protected function init(): void
     {
         if ($this->socket) {
-            return $this;
+            return;
         }
 
         $config = $this->config;
@@ -245,8 +245,14 @@ class Connection
             $this->connectMessage->name = $this->client->getName();
         }
 
-        $this->infoMessage = $this->getMessage($config->timeout);
-        assert($this->infoMessage instanceof Info);
+        $infoMessage = $this->getMessage($config->timeout);
+        if (is_null($infoMessage)) {
+            throw new Exception("Timeout waiting for message from server.");
+        }
+        if (!$infoMessage instanceof Info) {
+            throw new Exception("Received unexpected message type: " . $infoMessage::class);
+        }
+        $this->infoMessage = $infoMessage;
 
         if (isset($this->infoMessage->nonce) && $this->authenticator) {
             $this->connectMessage->sig = $this->authenticator->sign($this->infoMessage->nonce);


### PR DESCRIPTION
Fixes #92.

`Connection::getMessage()` returns ?Prototype but `Connection::infoMessage` only accepts `Info`.

Added two checks. A null result is treated as a timeout. A message of another inheritor of prototype is treated as an unexpected response.

I used Exception because that's what's already used, but a strong argument could be made for RuntimeException or a more specific type, especially for the timeout case, which can occur in practice and may be useful to catch separately.

I also removed $this from the return on line 223 and added "void" as Connection::init()'s return type after confirming that no callers of Connection::init() touch its return value.

One test (ConfigurationTest::testStreamConfigurationRestore) fails, but that appears to be a pre-existing issue; it also fails on main.
